### PR TITLE
feat(semantic-release): implement for this formula

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,54 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: '[BUG] '
+labels: 'bug'
+assignees: ''
+
+---
+
+<!--
+Notes:
+1. Only post _bug reports_ here.
+2. Use the appropriate template for _feature requests_.
+3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
+-->
+
+#### Describe the bug
+<!-- A clear and concise description of what the bug is. -->
+
+
+
+#### Setup
+<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->
+
+
+
+#### Steps to reproduce the bug
+<!-- Include debug logs if possible and relevant, e.g. using `salt-minion -l debug`. -->
+<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
+<!-- Most useful is providing a failing InSpec test, which can be used to verify any proposed fix. -->
+
+
+
+#### Expected behaviour
+<!-- A clear and concise description of what you expected to happen. -->
+
+
+
+#### Versions report
+<!-- Provided by running `salt --versions-report`. Please also mention any differences in master/minion versions. -->
+
+
+
+#### Additional context
+<!-- Add any other context about the problem here. -->
+
+
+
+---
+
+#### Optional: How can this template be improved?
+<!-- Feel free to suggest how this template can be improved. -->
+
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,42 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: '[FEATURE] '
+labels: 'enhancement'
+assignees: ''
+
+---
+
+<!--
+Notes:
+1. Only post _feature requests_ here.
+2. Use the appropriate template for _bug reports_.
+3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
+-->
+
+#### Is your feature request related to a problem?
+<!-- A clear and concise description of what the problem is. -->
+
+
+
+#### Describe the solution you'd like
+<!-- A clear and concise description of what you want to happen. -->
+
+
+
+#### Describe alternatives you've considered
+<!-- Describe any alternative solutions or features you've considered. -->
+
+
+
+#### Additional context
+<!-- Add any other context about the feature request here. -->
+
+
+
+---
+
+#### Optional: How can this template be improved?
+<!-- Feel free to suggest how this template can be improved. -->
+
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,16 @@
 # -*- coding: utf-8 -*-
 # vim: ft=yaml
 ---
+dist: bionic
 stages:
   - test
-  - commitlint
+  - lint
   - name: release
     if: branch = master AND type != pull_request
 
 sudo: required
 cache: bundler
 language: ruby
-dist: xenial
 
 services:
   - docker
@@ -25,40 +25,49 @@ env:
     # - INSTANCE: default-fedora-30-develop-py3
     # - INSTANCE: default-opensuse-leap-15-develop-py3
     # - INSTANCE: default-amazonlinux-2-develop-py2
+    # - INSTANCE: default-arch-base-latest-develop-py2
     # - INSTANCE: default-debian-9-2019-2-py3
     - INSTANCE: default-ubuntu-1804-2019-2-py3
-    # - INSTANCE: default-centos-7-2019-2-py3
-    # - INSTANCE: default-fedora-30-2019-2-py3
+    - INSTANCE: default-centos-7-2019-2-py3
+    - INSTANCE: default-fedora-30-2019-2-py3
     # - INSTANCE: default-opensuse-leap-15-2019-2-py3
-    - INSTANCE: default-amazonlinux-2-2019-2-py2
+    # - INSTANCE: default-amazonlinux-2-2019-2-py2
+    # - INSTANCE: default-arch-base-latest-2019-2-py2
     # - INSTANCE: default-debian-9-2018-3-py2
     # - INSTANCE: default-ubuntu-1604-2018-3-py2
     # - INSTANCE: default-centos-7-2018-3-py2
-    - INSTANCE: default-fedora-29-2018-3-py2
+    # - INSTANCE: default-fedora-29-2018-3-py2
     - INSTANCE: default-opensuse-leap-15-2018-3-py2
     # - INSTANCE: default-amazonlinux-2-2018-3-py2
+    # - INSTANCE: default-arch-base-latest-2018-3-py2
     # - INSTANCE: default-debian-8-2017-7-py2
-    # - INSTANCE: default-ubuntu-1604-2017-7-py2
-    - INSTANCE: centos6-centos-6-2017-7-py2
+    - INSTANCE: default-ubuntu-1604-2017-7-py2
+    # - INSTANCE: default-centos-6-2017-7-py2
     # - INSTANCE: default-fedora-29-2017-7-py2
     # - INSTANCE: default-opensuse-leap-15-2017-7-py2
     # - INSTANCE: default-amazonlinux-2-2017-7-py2
+    # - INSTANCE: default-arch-base-latest-2017-7-py2
 
 script:
   - bin/kitchen verify ${INSTANCE}
 
 jobs:
   include:
-    # Define the commitlint stage
-    - stage: commitlint
+    # Define the `lint` stage (runs `yamllint` and `commitlint`)
+    - stage: lint
       language: node_js
       node_js: lts/*
       before_install: skip
       script:
+        # Install and run `yamllint`
+        # Need at least `v1.17.0` for the `yaml-files` setting
+        - pip install --user yamllint>=1.17.0
+        - yamllint -s .
+        # Install and run `commitlint`
         - npm install @commitlint/config-conventional -D
         - npm install @commitlint/travis-cli -D
         - commitlint-travis
-    # Define the release stage that runs semantic-release
+    # Define the release stage that runs `semantic-release`
     - stage: release
       language: node_js
       node_js: lts/*

--- a/.yamllint
+++ b/.yamllint
@@ -6,10 +6,24 @@ extends: default
 
 # Files to ignore completely
 # 1. All YAML files under directory `node_modules/`, introduced during the Travis run
+# 2. Any SLS files under directory `test/`, which are actually state files
 ignore: |
   node_modules/
+  test/**/states/**/*.sls
+
+yaml-files:
+  # Default settings
+  - '*.yaml'
+  - '*.yml'
+  - .yamllint
+  # SaltStack Formulas additional settings
+  - '*.example'
+  - test/**/*.sls
 
 rules:
+  empty-values:
+    forbid-in-block-mappings: true
+    forbid-in-flow-mappings: true
   line-length:
     # Increase from default of `80`
     # Based on https://github.com/PyCQA/flake8-bugbear#opinionated-warnings (`B950`)

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -38,17 +38,32 @@ platforms:
         - sh bootstrap-salt.sh -XdPbfrq -x python3 git develop
   - name: opensuse-leap-15-develop-py3
     driver:
-      image: netmanagers/salt-develop-py3:opensuse-leap-15
+      image: opensuse/leap:15
       provision_command:
-        - curl -o bootstrap-salt.sh -L https://bootstrap.saltstack.com
-        - sh bootstrap-salt.sh -XdPbfrq -x python3 git develop
+        # yamllint disable-line rule:line-length
+        - zypper install -y glibc-locale net-tools net-tools-deprecated python-xml python3-pip
+        - systemctl enable sshd.service
       run_command: /usr/lib/systemd/systemd
+    provisioner:
+      salt_bootstrap_options: -XdPfrq -x python3 git develop
+      salt_install: bootstrap
+    # Workaround to avoid intermittent failures on `opensuse-leap-15`:
+    # => SCP did not finish successfully (255):  (Net::SCP::Error)
+    transport:
+      max_ssh_sessions: 1
   - name: amazonlinux-2-develop-py2
     driver:
       image: netmanagers/salt-develop-py2:amazonlinux-2
       provision_command:
         - curl -o bootstrap-salt.sh -L https://bootstrap.saltstack.com
         - sh bootstrap-salt.sh -XdPbfrq -x python2 git develop
+  - name: arch-base-latest-develop-py2
+    driver:
+      image: netmanagers/salt-develop-py2:arch-base-latest
+      provision_command:
+        - curl -o bootstrap-salt.sh -L https://bootstrap.saltstack.com
+        - sh bootstrap-salt.sh -XdPbfrq -x python2 git develop
+      run_command: /usr/lib/systemd/systemd
 
   ## SALT `2019.2`
   - name: debian-9-2019-2-py3
@@ -65,11 +80,26 @@ platforms:
       image: netmanagers/salt-2019.2-py3:fedora-30
   - name: opensuse-leap-15-2019-2-py3
     driver:
-      image: netmanagers/salt-2019.2-py3:opensuse-leap-15
+      image: opensuse/leap:15
+      provision_command:
+        # yamllint disable-line rule:line-length
+        - zypper install -y glibc-locale net-tools net-tools-deprecated python-xml python3-pip
+        - systemctl enable sshd.service
       run_command: /usr/lib/systemd/systemd
+    provisioner:
+      salt_bootstrap_options: -XdPfrq -x python3 git 2019.2
+      salt_install: bootstrap
+    # Workaround to avoid intermittent failures on `opensuse-leap-15`:
+    # => SCP did not finish successfully (255):  (Net::SCP::Error)
+    transport:
+      max_ssh_sessions: 1
   - name: amazonlinux-2-2019-2-py2
     driver:
       image: netmanagers/salt-2019.2-py2:amazonlinux-2
+  - name: arch-base-latest-2019-2-py2
+    driver:
+      image: netmanagers/salt-2019.2-py2:arch-base-latest
+      run_command: /usr/lib/systemd/systemd
 
   ## SALT `2018.3`
   - name: debian-9-2018-3-py2
@@ -86,11 +116,26 @@ platforms:
       image: netmanagers/salt-2018.3-py2:fedora-29
   - name: opensuse-leap-15-2018-3-py2
     driver:
-      image: netmanagers/salt-2018.3-py2:opensuse-leap-15
+      image: opensuse/leap:15
+      provision_command:
+        # yamllint disable-line rule:line-length
+        - zypper install -y glibc-locale net-tools net-tools-deprecated python-xml python2-pip
+        - systemctl enable sshd.service
       run_command: /usr/lib/systemd/systemd
+    provisioner:
+      salt_bootstrap_options: -XdPfrq -x python2 git 2018.3
+      salt_install: bootstrap
+    # Workaround to avoid intermittent failures on `opensuse-leap-15`:
+    # => SCP did not finish successfully (255):  (Net::SCP::Error)
+    transport:
+      max_ssh_sessions: 1
   - name: amazonlinux-2-2018-3-py2
     driver:
       image: netmanagers/salt-2018.3-py2:amazonlinux-2
+  - name: arch-base-latest-2018-3-py2
+    driver:
+      image: netmanagers/salt-2018.3-py2:arch-base-latest
+      run_command: /usr/lib/systemd/systemd
 
   ## SALT `2017.7`
   - name: debian-8-2017-7-py2
@@ -108,15 +153,30 @@ platforms:
       image: netmanagers/salt-2017.7-py2:fedora-29
   - name: opensuse-leap-15-2017-7-py2
     driver:
-      image: netmanagers/salt-2017.7-py2:opensuse-leap-15
+      image: opensuse/leap:15
+      provision_command:
+        # yamllint disable-line rule:line-length
+        - zypper install -y glibc-locale net-tools net-tools-deprecated python-xml python2-pip
+        - systemctl enable sshd.service
       run_command: /usr/lib/systemd/systemd
+    provisioner:
+      salt_bootstrap_options: -XdPfrq -x python2 git 2017.7
+      salt_install: bootstrap
+    # Workaround to avoid intermittent failures on `opensuse-leap-15`:
+    # => SCP did not finish successfully (255):  (Net::SCP::Error)
+    transport:
+      max_ssh_sessions: 1
   - name: amazonlinux-2-2017-7-py2
     driver:
       image: netmanagers/salt-2017.7-py2:amazonlinux-2
+  - name: arch-base-latest-2017-7-py2
+    driver:
+      image: netmanagers/salt-2017.7-py2:arch-base-latest
+      run_command: /usr/lib/systemd/systemd
 
 provisioner:
   name: salt_solo
-  log_level: info
+  log_level: debug
   salt_install: none
   require_chef: false
   formula: telegraf
@@ -134,26 +194,6 @@ verifier:
 
 suites:
   - name: default
-    excludes:
-      - centos-6-2017-7-py2
-    provisioner:
-      state_top:
-        base:
-          '*':
-            - telegraf
-      pillars:
-        top.sls:
-          base:
-            '*':
-              - telegraf
-      pillars_from_files:
-        telegraf.sls: test/salt/pillar/telegraf.sls
-    verifier:
-      inspec_tests:
-        - path: test/integration/default
-  - name: centos6
-    includes:
-      - centos-6-2017-7-py2
     provisioner:
       state_top:
         base:

--- a/telegraf/defaults.yaml
+++ b/telegraf/defaults.yaml
@@ -5,6 +5,7 @@ telegraf:
   config: /etc/telegraf/telegraf.conf
   system_user: root
   system_group: root
+  toml_pkg: python-pytoml
   pkg:
     name: telegraf
   service:

--- a/telegraf/map.jinja
+++ b/telegraf/map.jinja
@@ -47,3 +47,18 @@
 %}
 
 {%- set telegraf = config %}
+
+{#- Post-processing for specific non-YAML customisations #}
+{%- if grains.pythonversion[0] == 2 %}
+{%-   if grains.os in ['Fedora'] %}
+{%-     do telegraf.update({'toml_pkg': 'python2-toml'}) %}
+{%-   elif grains.os in ['openSUSE', 'SUSE'] %}
+{%-     do telegraf.update({'toml_pkg': 'python2-pytoml'}) %}
+{%-   endif %}
+{%- elif grains.pythonversion[0] == 3 %}
+{%-   if grains.os in ['CentOS'] %}
+{%-     do telegraf.update({'toml_pkg': 'python36-pytoml'}) %}
+{%-   else %}
+{%-     do telegraf.update({'toml_pkg': 'python3-pytoml'}) %}
+{%-   endif %}
+{%- endif %}

--- a/telegraf/osfamilymap.yaml
+++ b/telegraf/osfamilymap.yaml
@@ -32,4 +32,5 @@ Suse:
     name: go
     enabled: 1
     gpgautoimport: true
+    # yamllint disable-line rule:line-length
     baseurl: https://download.opensuse.org/repositories/devel:/languages:/go/openSUSE_Leap_$releasever

--- a/telegraf/osfingermap.yaml
+++ b/telegraf/osfingermap.yaml
@@ -10,66 +10,11 @@
 # you will need to provide at least an empty dict in this file, e.g.
 # osfingermap: {}
 ---
-Debian-10:
-{% if grains['pythonversion'][0] == 3 %}
-  toml_pkg: python3-pytoml
-{% else %}
-  toml_pkg: python-pytoml
-{% endif %}
-
-Debian-9:
-{% if grains['pythonversion'][0] == 3 %}
-  toml_pkg: python3-pytoml
-{% else %}
-  toml_pkg: python-pytoml
-{% endif %}
-
-Debian-8:
-  toml_pkg: python-pytoml
-
-Ubuntu-18.04:
-  toml_pkg: python3-pytoml
-
-Ubuntu-16.04:
-  toml_pkg: python-pytoml
-
-CentOS Linux-7:
-{% if grains['pythonversion'][0] == 3 %}
-  toml_pkg: python36-pytoml
-{% else %}
-  toml_pkg: python-pytoml
-{% endif %}
-
-Fedora-29:
-{% if grains['pythonversion'][0] == 3 %}
-  toml_pkg: python3-pytoml
-{% else %}
-  toml_pkg: python2-toml
-{% endif %}
-
-Fedora-28:
-{% if grains['pythonversion'][0] == 3 %}
-  toml_pkg: python3-pytoml
-{% else %}
-  toml_pkg: python2-pytoml
-{% endif %}
-
-Leap-15:
-{% if grains['pythonversion'][0] == 3 %}
-  toml_pkg: python3-pytoml
-{% else %}
-  toml_pkg: python2-pytoml
-{% endif %}
-
 Leap-42:
-{% if grains['pythonversion'][0] == 3 %}
-  toml_pkg: python3-pytoml
-{% else %}
-  toml_pkg: python-pytoml
-{% endif %}
   repo_python:
     humanname: Python backports
     name: python-backports
     enabled: 1
     gpgautoimport: true
+    # yamllint disable-line rule:line-length
     baseurl: https://download.opensuse.org/repositories/devel:/languages:/python:/backports/openSUSE_Leap_$releasever

--- a/test/integration/default/inspec.yml
+++ b/test/integration/default/inspec.yml
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
 ---
 name: default
 title: telegraf formula
@@ -13,3 +15,4 @@ supports:
   - platform-name: suse
   - platform-name: freebsd
   - platform-name: amazon
+  - platform-name: arch


### PR DESCRIPTION
* Automated using https://github.com/myii/ssf-formula/pull/55
* Close #1

---

@n-rodriguez Before merging this, the first release should be created.

---

This is working on all instances except for `amazonlinux-2` and `arch-base-latest`:

* https://travis-ci.org/myii/telegraf-formula/builds/592768977
* https://travis-ci.org/myii/telegraf-formula/builds/592791086

To get this working on Arch, the following references are helpful:

* https://wiki.archlinux.org/index.php/Telegraf
* https://aur.archlinux.org/packages/telegraf/
  - This would require `git.latest`
  - Start from https://github.com/saltstack-formulas/iscsi-formula/blob/aa5a94555a46b81ffa2d4efe579deaf0ce0c965b/iscsi/osfamilymap.yaml#L70
* https://www.archlinux.org/packages/?sort=&q=pytoml&maintainer=&flagged=
  - This is already working